### PR TITLE
Update mixture_summaries.R

### DIFF
--- a/R/mixture_summaries.R
+++ b/R/mixture_summaries.R
@@ -248,31 +248,38 @@ icl_default <- function(post_prob, BIC){
 #' res <- mx_mixture(model = "x ~ m{C}*1
 #'                            x ~~ v{C}*x", classes = 1:2, data = df)
 #' BLRT(res, replications = 4)
+#' res <- mx_mixture(model = "x ~ m{C}*1
+#'                            x ~~ v{C}*x", classes = 1, data = df)
+#' BLRT(res, replications = 4)      
 #' }
 #' @export
 BLRT <- function(x, ...){
   UseMethod("BLRT", x)
 }
 
-#' @method BLRT mixture_list
-#' @export
 BLRT.mixture_list <- function(x, ...){
   if(length(x) > 1){
     out <- mapply(function(k, km1){
       tryCatch({
         unlist(mxCompare(k, km1, boot = TRUE, ...)[2, c("diffLL", "diffdf", "p")])
-        },
-               error = function(e){
-                 c("diffLL" = NA, "diffdf" = NA, "p" = NA)
-               })
+      },
+      error = function(e){
+        c("diffLL" = NA, "diffdf" = NA, "p" = NA)
+      })
     }, k = x[-1], km1 = x[-length(x)])
-    rbind(data.frame(diffLL = NA, diffdf = NA, p = NA),
-          t(out))
+    res <- rbind(data.frame(diffLL = NA, diffdf = NA, p = NA), t(out))
+    if(all(is.na(res))) warning("Please check BLRT function, it should include specific argument name. e.g., BLRT(res, replications = 4), not BLRT(res, 4)")
   } else {
-    data.frame(diffLL = NA, diffdf = NA, p = NA)
+    res <- data.frame(diffLL = NA, diffdf = NA, p = NA)
   }
+  return(res)
 }
+
 
 #' @method BLRT list
 #' @export
 BLRT.list <- BLRT.mixture_list
+
+#' @method BLRT MxRAMModel
+#' @export
+BLRT.MxRAMModel <- BLRT.mixture_list


### PR DESCRIPTION
1. adding MxRAMModel method to cope with Error in UseMethod("BLRT", x) : 
  no applicable method for 'BLRT' applied to an object of class "c('MxRAMModel', 'MxModel')" 

``` r
library(tidySEM)
#> Loading required package: OpenMx
# only 1 class 
 res <- mx_mixture(
  model = "x ~ m{C}*1
           x ~~ v{C}*x",
  classes = 1,
  data = df
)
#> Running mix1 with 2 parameters

BLRT(res, replications = 4)
#> Error in UseMethod("BLRT", x): no applicable method for 'BLRT' applied to an object of class "c('MxRAMModel', 'MxModel')"
```
2. adding a warning message when the user forgets to specify the argument name.  

``` r
library(tidySEM)
#> Loading required package: OpenMx
df <- iris[, 1, drop = FALSE]
names(df) <- "x"
res <- mx_mixture(model = "x ~ m{C}*1
                           x ~~ v{C}*x", 
                  class = 1:2, 
                  data = df
                  )
#> Running mix1 with 2 parameters
#> Running mix2 with 5 parameters
#> Running mix2 with 5 parameters

BLRT(res, 4)
#> Warning in BLRT.mixture_list(res, 4): Please check BLRT function, it should
#> include specific argument name. e.g., BLRT(res, replications = 4), not BLRT(res,
#> 4)
#>   diffLL diffdf  p
#> 1     NA     NA NA
#> 2     NA     NA NA
```

<sup>Created on 2022-12-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

